### PR TITLE
[ADD]관리자리스트 레이아웃작업

### DIFF
--- a/src/components/Admin/AdminShop/AdminShop.jsx
+++ b/src/components/Admin/AdminShop/AdminShop.jsx
@@ -1,8 +1,28 @@
 import React from 'react'
 import * as S from './AdminShop.style'
+import AdminShopItem from '../AdminShopItem/AdminShopItem'
 
 const AdminShop = () => {
-  return <div>관리자 상품관리페이지</div>
+  return (
+    <S.AdminShopContainer>
+      <S.AdminShopHeader>
+        <S.AdminShopHeaderRow>
+          <S.AdminVisible>노출 여부</S.AdminVisible>
+          <S.AdminProductCode>상품코드</S.AdminProductCode>
+          <S.AdminProductImg>이미지</S.AdminProductImg>
+          <S.AdminProductName>상품명</S.AdminProductName>
+          <S.AdminProductPrice>가격</S.AdminProductPrice>
+          <S.AdminProductQuantity>수량</S.AdminProductQuantity>
+          <S.AdminProductSale>할인율</S.AdminProductSale>
+          <S.AdminProductStatus>상태</S.AdminProductStatus>
+          <S.AdminButton />
+        </S.AdminShopHeaderRow>
+      </S.AdminShopHeader>
+      <S.AdminShopBody>
+        <AdminShopItem></AdminShopItem>
+      </S.AdminShopBody>
+    </S.AdminShopContainer>
+  )
 }
 
 export default AdminShop

--- a/src/components/Admin/AdminShop/AdminShop.style.js
+++ b/src/components/Admin/AdminShop/AdminShop.style.js
@@ -1,1 +1,80 @@
 import styled from 'styled-components'
+import StyleVariables from '../../../styles/StyleVariables'
+
+export const AdminShopContainer = styled.table`
+  width: 1200px;
+  margin: 20px auto;
+  border: 1px solid black;
+  border-bottom: none;
+`
+
+export const AdminShopHeader = styled.thead`
+  ${StyleVariables.headerFont}
+`
+
+export const AdminShopHeaderRow = styled.tr`
+  ${StyleVariables.flex()}
+  height: 60px;
+  padding: 20px;
+  border-bottom: 1px solid black;
+`
+
+export const AdminShopBody = styled.tbody``
+
+const AdminCommonStyle = styled.td`
+  ${StyleVariables.flex()}
+`
+
+const AdminVisibleColumn = styled(AdminCommonStyle)`
+  flex: 0.8;
+`
+
+const AdminProductCodeColumn = styled(AdminCommonStyle)`
+  flex: 1;
+`
+
+const AdminProductImgColumn = styled(AdminCommonStyle)`
+  flex: 1;
+`
+
+const AdminProductNameColumn = styled(AdminCommonStyle)`
+  flex: 2;
+`
+
+const AdminProductPriceColumn = styled(AdminCommonStyle)`
+  flex: 1;
+`
+
+const AdminProductQuantityColumn = styled(AdminCommonStyle)`
+  flex: 0.8;
+`
+
+const AdminProductSaleColumn = styled(AdminCommonStyle)`
+  flex: 0.8;
+`
+
+const AdminProductStatusColumn = styled(AdminCommonStyle)`
+  flex: 0.8;
+`
+
+const AdminButtonColumn = styled(AdminCommonStyle)`
+  flex: 1;
+`
+
+export const AdminVisible = styled(AdminVisibleColumn)``
+
+export const AdminProductCode = styled(AdminProductCodeColumn)``
+
+export const AdminProductImg = styled(AdminProductImgColumn)``
+
+export const AdminProductName = styled(AdminProductNameColumn)``
+
+export const AdminProductPrice = styled(AdminProductPriceColumn)``
+
+export const AdminProductQuantity = styled(AdminProductQuantityColumn)``
+
+export const AdminProductSale = styled(AdminProductSaleColumn)``
+
+export const AdminProductStatus = styled(AdminProductStatusColumn)``
+
+export const AdminButton = styled(AdminButtonColumn)``

--- a/src/components/Admin/AdminShopItem/AdminShopItem.jsx
+++ b/src/components/Admin/AdminShopItem/AdminShopItem.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import * as S from './AdminShopItme.style'
+import Status from '../../common/Status/Status'
+
+const STATUS = ['sale', 'best']
+
+const AdminShopItem = () => (
+  <S.AdminShopItemContainer>
+    <S.AdminVisible>
+      <S.VisibleBox type="checkbox" />
+    </S.AdminVisible>
+    <S.AdminProductCode>상품코드</S.AdminProductCode>
+    <S.AdminProductImg>
+      <S.ProductImg
+        src="https://cdn.imweb.me/thumbnail/20200715/236fbfcdd9cf2.jpg"
+        alt="상품관련사진"
+      />
+    </S.AdminProductImg>
+    <S.AdminProductName>상품명</S.AdminProductName>
+    <S.AdminProductPrice>가격</S.AdminProductPrice>
+    <S.AdminProductQuantity>수량</S.AdminProductQuantity>
+    <S.AdminProductSale>할인율</S.AdminProductSale>
+    <S.AdminProductStatus>
+      {STATUS.map((status, index) => (
+        <Status key={index} status={status} />
+      ))}
+    </S.AdminProductStatus>
+    <S.AdminButtonContainer>
+      <S.AdminButton>수정하기</S.AdminButton>
+      <S.AdminButton>삭제하기</S.AdminButton>
+    </S.AdminButtonContainer>
+  </S.AdminShopItemContainer>
+)
+
+export default AdminShopItem

--- a/src/components/Admin/AdminShopItem/AdminShopItme.style.js
+++ b/src/components/Admin/AdminShopItem/AdminShopItme.style.js
@@ -1,0 +1,48 @@
+import styled from 'styled-components'
+import StyleVariables from '../../../styles/StyleVariables'
+import * as S from '../AdminShop/AdminShop.style'
+
+export const AdminShopItemContainer = styled.tr`
+  ${StyleVariables.flex()}
+  height: 155px;
+  padding: 20px;
+  border-bottom: 1px solid black;
+`
+
+export const VisibleBox = styled.input``
+
+export const ProductImg = styled.img`
+  width: 120px;
+  height: 120px;
+`
+
+export const AdminVisible = styled(S.AdminVisible)``
+
+export const AdminProductCode = styled(S.AdminProductCode)``
+
+export const AdminProductImg = styled(S.AdminProductImg)``
+
+export const AdminProductName = styled(S.AdminProductName)``
+
+export const AdminProductPrice = styled(S.AdminProductPrice)``
+
+export const AdminProductQuantity = styled(S.AdminProductQuantity)``
+
+export const AdminProductSale = styled(S.AdminProductSale)``
+
+export const AdminProductStatus = styled(S.AdminProductStatus)`
+  ${StyleVariables.flex('column', 'space-evenly')}
+  height: 100%;
+`
+
+export const AdminButtonContainer = styled(S.AdminButton)`
+  ${StyleVariables.flex('column', 'space-between')}
+  height: 100%;
+`
+
+export const AdminButton = styled.button`
+  ${StyleVariables.flex()}
+  width: 130px;
+  height: 50px;
+  background-color: aliceblue;
+`

--- a/src/components/common/Status/Status.style.js
+++ b/src/components/common/Status/Status.style.js
@@ -21,6 +21,8 @@ export const StatusContainer = styled.div`
           color: red;
           border: 1px solid black;
         `
+      default:
+        return css``
     }
   }}
 `

--- a/src/styles/StyleVariables.js
+++ b/src/styles/StyleVariables.js
@@ -1,0 +1,22 @@
+import { css } from 'styled-components'
+
+export const StyleVariables = {
+  flex: (direction = 'row', justify = 'center', align = 'center') => `
+    display: flex;
+    flex-direction: ${direction};
+    justify-content: ${justify};
+    align-items: ${align};
+  `,
+
+  headerFont: css`
+    font-size: 18px;
+    font-weight: 700;
+  `,
+
+  normalFont: css`
+    font-size: 16px;
+    font-weight: 400;
+  `,
+}
+
+export default StyleVariables


### PR DESCRIPTION
관리자페이지의 기본적인레이아웃구성

### 작업내용
기본적인 레이아웃 구성, Table로 작성하였습니다.
각 열의 너비는 flex를 이용하여 구분짓고 아래열과 동일한 스타일로 가는형식으로 구성하였습니다.

<img width="571" alt="스크린샷 2022-09-04 오후 3 58 58" src="https://user-images.githubusercontent.com/97271725/188301489-8c05a9cc-9d5f-418d-a0fc-d0c53d2b88ea.png">
Style 폴더에 공용으로 사용되는 스타일 형식을 변수로 저장하고,

<img width="577" alt="스크린샷 2022-09-04 오후 3 59 25" src="https://user-images.githubusercontent.com/97271725/188301500-841ef22b-85d2-4bfb-b468-5b02288acf9d.png">
이렇게 중복되는 부분들을 선택하여 사용할 수 있도록 하였습니다.

### 아쉬운점
Table로 작성을 할지 그냥 Div형식으로 구성할지 고민중입니다.