### PR TITLE
[RFT] 페이지네이션 변수명 수정 및 상수 ref로 변경

### DIFF
--- a/src/components/FruitStore/FruitStoreList/FruitStoreList.jsx
+++ b/src/components/FruitStore/FruitStoreList/FruitStoreList.jsx
@@ -7,8 +7,6 @@ import useProductApi from '../../../utils/useProductApi'
 const FruitStoreList = () => {
   const [data, setData] = useState([])
   const [total, setTotal] = useState(0)
-  const [activedPage, setActivedPage] = useState(1)
-  const limit = 10
 
   const { getProducts } = useProductApi()
 
@@ -36,13 +34,7 @@ const FruitStoreList = () => {
       </S.GridWrapper>
 
       <S.PaginationWrapper>
-        <Pagination
-          total={total}
-          limit={limit}
-          activedPage={activedPage}
-          setActivedPage={setActivedPage}
-          getDatas={getDatas}
-        />
+        <Pagination total={total} getDatas={getDatas} />
       </S.PaginationWrapper>
     </>
   )

--- a/src/components/common/Pagination/Pagination.jsx
+++ b/src/components/common/Pagination/Pagination.jsx
@@ -1,26 +1,32 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { useState } from 'react'
 import * as S from './Pagination.style'
 
-const Pagination = ({ total, limit, activedPage, setActivedPage, getDatas }) => {
+const Pagination = ({ total, getDatas }) => {
   const [startPage, setStartPage] = useState(1)
-  const lastPage = Math.ceil(total / limit)
+  const [activedPage, setActivedPage] = useState(1)
+
+  const BLOCK_NUM = useRef(5).current
+  const ITEM_PER_PAGE = useRef(10).current
+  const PAGE_LENGTH = Math.ceil(total / ITEM_PER_PAGE)
 
   const onClickPage = ({ target }) => {
     setActivedPage(Number(target.id))
     getDatas(Number(target.id))
   }
+
   const onClickPrev = () => {
     if (startPage === 1) return
-    setStartPage(prev => prev - limit)
-    setActivedPage(startPage - limit)
-    getDatas(activedPage)
+    setStartPage(prev => prev - BLOCK_NUM)
+    getDatas(startPage - BLOCK_NUM)
+    setActivedPage(startPage - BLOCK_NUM)
   }
+
   const onClickNext = () => {
-    if (startPage + limit > lastPage) return
-    setStartPage(prev => prev + limit)
-    setActivedPage(startPage + limit)
-    getDatas(activedPage)
+    if (startPage + ITEM_PER_PAGE > PAGE_LENGTH) return
+    setStartPage(prev => prev + BLOCK_NUM)
+    getDatas(startPage + BLOCK_NUM)
+    setActivedPage(startPage + BLOCK_NUM)
   }
 
   return (
@@ -28,13 +34,13 @@ const Pagination = ({ total, limit, activedPage, setActivedPage, getDatas }) => 
       <S.PageButton disabled={startPage === 1} onClick={onClickPrev}>
         &lt;
       </S.PageButton>
-      {new Array(5).fill(1).map((_, idx) => {
+      {new Array(BLOCK_NUM).fill(1).map((_, idx) => {
         return (
-          idx + startPage <= lastPage && (
+          idx + startPage <= PAGE_LENGTH && (
             <S.PageButton
               id={String(idx + startPage)}
               onClick={onClickPage}
-              key={idx}
+              key={idx + startPage}
               isActive={idx + startPage === activedPage}
             >
               {idx + startPage}
@@ -42,7 +48,7 @@ const Pagination = ({ total, limit, activedPage, setActivedPage, getDatas }) => 
           )
         )
       })}
-      <S.PageButton disabled={startPage + limit > lastPage} onClick={onClickNext}>
+      <S.PageButton disabled={startPage + ITEM_PER_PAGE > PAGE_LENGTH} onClick={onClickNext}>
         &gt;
       </S.PageButton>
     </S.PaginationWrapper>


### PR DESCRIPTION
변경사항
* 변수 가독성을 위해 상수 대문자로 수정,상수의 리렌더링 방지하고자 ref로 변경

이슈 및 해결되지 않음
* startPage, activedPage을 state로 변경하게 되면 get 요청 이후 렌더링이 한번 더 일어나는 문제 제기
* 이후 useRef로 시도했으나 페이지 클릭 후 현재 페이지의 스타일이 변경되지 않는, 즉 렌더링이 되지 않는 문제 발생
* get 요청에 데이터를 변경하는 setState가 있어 리렌더링이 불가피하다고 생각하였습니다.