### PR TITLE
[ADD] 캐러셀 컴포넌트 추가 및 텍스트를 캐러셀로 이동

### DIFF
--- a/src/components/FruitStore/FruitStoreList/FruitStoreList.style.js
+++ b/src/components/FruitStore/FruitStoreList/FruitStoreList.style.js
@@ -7,7 +7,7 @@ export const GridWrapper = styled.div`
 `
 export const Title = styled.h2`
   display: flex;
-  margin-bottom: 10px;
+  margin: 10px 0;
 `
 export const TitleStrong = styled.strong`
   margin-left: 5px;

--- a/src/components/common/Carousel/Carousel.jsx
+++ b/src/components/common/Carousel/Carousel.jsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useRef, useState } from 'react'
+import * as S from './Carousel.style'
+
+const BannerShipping = () => {
+  return (
+    <S.TextTable>
+      <S.TextWrapper>
+        <S.LogoImg src={process.env.PUBLIC_URL + '/assets/logo.png'} />
+        <S.TextStrong>프루떼 [ 수확배송 ]</S.TextStrong>
+      </S.TextWrapper>
+      <S.TextWrapper>
+        <S.Text>
+          친환경 농가의 맛있고 바른 먹거리를 만났을때 게릴라로 열리는 프루떼의 반짝스토어
+        </S.Text>
+        <S.Text>가장 알맞게 익었을때 농장에서 바로! 수확해서 배송해드립니다.</S.Text>
+      </S.TextWrapper>
+    </S.TextTable>
+  )
+}
+const BannerFarmer = () => {
+  return (
+    <S.TextTable>
+      <S.TextWrapper>
+        <S.LogoImg src={process.env.PUBLIC_URL + '/assets/logo.png'} />
+        <S.TextStrong>우리농가 파트너 [ 프룻파머 ]</S.TextStrong>
+      </S.TextWrapper>
+      <S.TextWrapper>
+        <S.Text>
+          프루떼는 다음 세대의 환경과 바른 먹거리를 생각하는 농가파트너 ‘프룻파머’와 함께합니다.
+        </S.Text>
+        <S.Text>넓고 푸른 환경에서 준비한 피크닉으로 여러분을 초대하기도 하고,</S.Text>
+        <S.Text>
+          반짝 스토어에서는 친환경 신념을 지키며 정성껏 기른 농가의 작물들을 엄선하여 소개하고
+          있습니다.
+        </S.Text>
+        <S.Text>
+          프루떼 피크닉과 반짝스토어를 통해 친환경 농장을 알고 맛보는 기쁨까지 얻으실 수 있습니다
+        </S.Text>
+      </S.TextWrapper>
+    </S.TextTable>
+  )
+}
+
+const Carousel = () => {
+  const totalIdx = 1
+  const [currentIdx, setCurrentIdx] = useState(0)
+  const slideRef = useRef(null)
+
+  const onClickPrev = () => {
+    if (currentIdx === 0) {
+      setCurrentIdx(totalIdx)
+    } else {
+      setCurrentIdx(currentIdx - 1)
+    }
+  }
+
+  const onClickNext = () => {
+    if (currentIdx >= totalIdx) {
+      setCurrentIdx(0)
+    } else {
+      setCurrentIdx(currentIdx + 1)
+    }
+  }
+
+  useEffect(() => {
+    slideRef.current.style.transition = 'all 0.5s ease-in-out'
+    slideRef.current.style.transform = `translateX(-${currentIdx}00%)`
+  }, [currentIdx])
+
+  return (
+    <S.Wrapper>
+      <S.FlexWrapper>
+        <S.SlideWrapper ref={slideRef}>
+          <S.SlideItem>
+            <BannerShipping />
+          </S.SlideItem>
+          <S.SlideItem>
+            <BannerFarmer />
+          </S.SlideItem>
+        </S.SlideWrapper>
+        <S.LeftButton onClick={onClickPrev}>&lt;</S.LeftButton>
+        <S.RightButton onClick={onClickNext}>&gt;</S.RightButton>
+      </S.FlexWrapper>
+    </S.Wrapper>
+  )
+}
+export default Carousel

--- a/src/components/common/Carousel/Carousel.style.js
+++ b/src/components/common/Carousel/Carousel.style.js
@@ -1,0 +1,74 @@
+import styled from 'styled-components'
+
+export const Wrapper = styled.div`
+  width: 100%;
+  height: 300px;
+  overflow: hidden;
+`
+export const FlexWrapper = styled.div`
+  display: flex;
+`
+export const SlideWrapper = styled.div`
+  display: flex;
+`
+export const SlideImg = styled.img`
+  width: 100%;
+  height: 300px;
+  object-fit: contain;
+  flex: none;
+`
+export const SlideItem = styled.div`
+  width: 100%;
+  height: 300px;
+  object-fit: contain;
+  flex: none;
+`
+export const LeftButton = styled.div`
+  cursor: pointer;
+  position: absolute;
+  top: 25%;
+  left: 10%;
+  font-size: 1.5rem;
+  color: #d4d4d4;
+  z-index: 10;
+  user-select: none;
+`
+export const RightButton = styled.button`
+  position: absolute;
+  cursor: pointer;
+  top: 25%;
+  right: 10%;
+  font-size: 1.5rem;
+  color: #d4d4d4;
+  z-index: 10;
+  user-select: none;
+`
+export const TextTable = styled.div`
+  width: 100%;
+  height: 300px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 15px 0;
+`
+export const TextStrong = styled.h5`
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 10px 0;
+`
+export const Text = styled.p`
+  font-size: 1rem;
+  color: #404040;
+  line-height: 27px;
+`
+export const LogoImg = styled.img`
+  width: 35px;
+  height: 35px;
+  margin: 10px 0;
+`

--- a/src/pages/FruitStore/FruitStore.jsx
+++ b/src/pages/FruitStore/FruitStore.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Carousel from '../../components/common/Carousel/Carousel'
 import FruitStoreList from '../../components/FruitStore/FruitStoreList/FruitStoreList'
 import * as S from './FruitStore.style'
 
@@ -7,41 +8,9 @@ const FruitStore = () => {
     <S.MainWrapper>
       <S.FruitStoreListWrapper>
         <S.Wrapper />
-        <S.TextTable>
-          <S.TextWrapper>
-            <S.LogoImg src={process.env.PUBLIC_URL + '/assets/logo.png'} />
-            <S.TextStrong>프루떼 [ 수확배송 ]</S.TextStrong>
-          </S.TextWrapper>
-          <S.TextWrapper>
-            <S.Text>
-              친환경 농가의 맛있고 바른 먹거리를 만났을때 게릴라로 열리는 프루떼의 반짝스토어
-            </S.Text>
-            <S.Text>가장 알맞게 익었을때 농장에서 바로! 수확해서 배송해드립니다.</S.Text>
-          </S.TextWrapper>
-        </S.TextTable>
-
+        <Carousel />
         <FruitStoreList />
-
-        <S.TextTable>
-          <S.TextWrapper>
-            <S.LogoImg src={process.env.PUBLIC_URL + '/assets/logo.png'} />
-            <S.TextStrong>우리농가 파트너 [ 프룻파머 ]</S.TextStrong>
-          </S.TextWrapper>
-          <S.TextWrapper>
-            <S.Text>
-              프루떼는 다음 세대의 환경과 바른 먹거리를 생각하는 농가파트너 ‘프룻파머’와 함께합니다.
-            </S.Text>
-            <S.Text>넓고 푸른 환경에서 준비한 피크닉으로 여러분을 초대하기도 하고,</S.Text>
-            <S.Text>
-              반짝 스토어에서는 친환경 신념을 지키며 정성껏 기른 농가의 작물들을 엄선하여 소개하고
-              있습니다.
-            </S.Text>
-            <S.Text>
-              프루떼 피크닉과 반짝스토어를 통해 친환경 농장을 알고 맛보는 기쁨까지 얻으실 수
-              있습니다
-            </S.Text>
-          </S.TextWrapper>
-        </S.TextTable>
+        <S.Wrapper />
       </S.FruitStoreListWrapper>
     </S.MainWrapper>
   )

--- a/src/pages/FruitStore/FruitStore.style.js
+++ b/src/pages/FruitStore/FruitStore.style.js
@@ -16,30 +16,3 @@ export const Wrapper = styled.div`
   width: 100%;
   height: 100px;
 `
-export const TextTable = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin: 50px 0;
-`
-export const TextWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin: 15px 0;
-`
-export const TextStrong = styled.h5`
-  font-size: 1.75rem;
-  font-weight: 700;
-  margin: 10px 0;
-`
-export const Text = styled.p`
-  font-size: 1rem;
-  color: #404040;
-  line-height: 27px;
-`
-export const LogoImg = styled.img`
-  width: 35px;
-  height: 35px;
-  margin: 10px 0;
-`


### PR DESCRIPTION
* 상품목록 하단 텍스트가 눈에 띄지 않아 최상단 캐러셀로 이동
* 캐러셀로 아래 사진들을 한번에 표시했습니다.
![스크린샷 2022-09-04 20 19 19](https://user-images.githubusercontent.com/59791809/188318815-fb99a7ca-e3a7-4acd-bdf7-073e97391d70.png)
![스크린샷 2022-09-04 20 19 29](https://user-images.githubusercontent.com/59791809/188318820-1b8c9e51-abcb-4a36-994a-1204b8e86639.png)
