### PR TITLE
[FIX] 어드민페이지 레이아웃수정

### DIFF
--- a/src/pages/Admin/Admin.style.js
+++ b/src/pages/Admin/Admin.style.js
@@ -4,6 +4,7 @@ import StyleVariables from '../../styles/StyleVariables'
 export const AdminMainPage = styled.div`
   width: 1300px;
   padding: 0 50px;
+  margin: 0 auto;
 `
 
 export const AdminPageHeader = styled.div`


### PR DESCRIPTION
가운데정렬적용

margin: auto 속성으로 창을 가운데 정렬로 맞추어놓았습니다.